### PR TITLE
[#5] Unwrap dimensions properly

### DIFF
--- a/lib/ex_aws/cloudwatch.ex
+++ b/lib/ex_aws/cloudwatch.ex
@@ -555,7 +555,30 @@ defmodule ExAws.Cloudwatch do
   * The SampleCount value of the statistic set is 1
   * The Min and the Max values of the statistic set are equal
 
-
+  ## Example
+      iex> metric_data = [
+      ...>   [metric_name: "My Metric Name", value: 1.0],
+      ...>   [metric_name: "My Metric Name", value: 1.5],
+      ...>   [metric_name: "My Metric Name", value: 2.0],
+      ...> ]
+      iex> ExAws.Cloudwatch.put_metric_data(metric_data, "My Name Space")
+      %ExAws.Operation.Query{
+        action: :put_metric_data,
+        params: %{
+          "Action" => "PutMetricData",
+          "MetricData.member.1.MetricName" => "My Metric Name",
+          "MetricData.member.1.Value" => 1.0,
+          "MetricData.member.2.MetricName" => "My Metric Name",
+          "MetricData.member.2.Value" => 1.5,
+          "MetricData.member.3.MetricName" => "My Metric Name",
+          "MetricData.member.3.Value" => 2.0,
+          "Namespace" => "My Name Space",
+          "Version" => "2010-08-01",
+        },
+        parser: &ExAws.Cloudwatch.Parsers.parse/2,
+        path: "/",
+        service: :monitoring,
+      }
   """
   @spec put_metric_data(metric_data :: [metric_datum, ...], namespace :: binary) ::
           ExAws.Operation.Query.t()
@@ -627,8 +650,13 @@ defmodule ExAws.Cloudwatch do
 
   defp format_param({:metric_data, metric_data}) do
     metric_data
-    |> Enum.flat_map(&format_param/1)
-    |> ExAws.Utils.format(prefix: "MetricData.member")
+    |> Enum.map(&{:metric_datum, &1})
+    |> Enum.map(&format_param/1)
+    |> format(prefix: "MetricData.member")
+  end
+
+  defp format_param({:metric_datum, metric_datum}) do
+    metric_datum |> Enum.flat_map(&format_param/1)
   end
 
   defp format_param({:ok_actions, ok_actions}) do

--- a/test/lib/cloudwatch_test.exs
+++ b/test/lib/cloudwatch_test.exs
@@ -7,4 +7,75 @@ defmodule ExAws.CloudwatchTest do
     expected = %{"Action" => "DescribeAlarms", "Version" => "2010-08-01"}
     assert expected == Cloudwatch.describe_alarms().params
   end
+
+  test "#put_metric_data" do
+    metric_datum = [
+      metric_name: "My Metric Name",
+      dimensions: [
+        my_dim_1: "dim_1_value",
+        my_dim_2: "dim_2_value"
+      ],
+      # TODO #7 fix to be able to pass timestame value as DateTime struct
+      # timestamp: DateTime.from_unix!(1529463103),
+      unit: "Count",
+      storage_resolution: 1,
+
+      # In production, either :statistic_values or :value is required.
+      statistic_values: [
+        maximum: 6,
+        minimum: 4,
+        sample_count: 3,
+        sum: 15
+      ],
+      value: 1.0
+    ]
+
+    metric_data = [metric_datum, metric_datum, metric_datum]
+    expected = %{
+      "Action" => "PutMetricData",
+      "MetricData.member.1.Dimensions.member.1.Name" => "my_dim_1",
+      "MetricData.member.1.Dimensions.member.1.Value" => "dim_1_value",
+      "MetricData.member.1.Dimensions.member.2.Name" => "my_dim_2",
+      "MetricData.member.1.Dimensions.member.2.Value" => "dim_2_value",
+      "MetricData.member.1.MetricName" => "My Metric Name",
+      "MetricData.member.1.StatisticValues.Maximum" => 6,
+      "MetricData.member.1.StatisticValues.Minimum" => 4,
+      "MetricData.member.1.StatisticValues.SampleCount" => 3,
+      "MetricData.member.1.StatisticValues.Sum" => 15,
+      "MetricData.member.1.StorageResolution" => 1,
+      # "MetricData.member.1.Timestamp" => 1529463103000,
+      "MetricData.member.1.Unit" => "Count",
+      "MetricData.member.1.Value" => 1.0,
+      "MetricData.member.2.Dimensions.member.1.Name" => "my_dim_1",
+      "MetricData.member.2.Dimensions.member.1.Value" => "dim_1_value",
+      "MetricData.member.2.Dimensions.member.2.Name" => "my_dim_2",
+      "MetricData.member.2.Dimensions.member.2.Value" => "dim_2_value",
+      "MetricData.member.2.MetricName" => "My Metric Name",
+      "MetricData.member.2.StatisticValues.Maximum" => 6,
+      "MetricData.member.2.StatisticValues.Minimum" => 4,
+      "MetricData.member.2.StatisticValues.SampleCount" => 3,
+      "MetricData.member.2.StatisticValues.Sum" => 15,
+      "MetricData.member.2.StorageResolution" => 1,
+      # "MetricData.member.2.Timestamp" => 1529463103000,
+      "MetricData.member.2.Unit" => "Count",
+      "MetricData.member.2.Value" => 1.0,
+      "MetricData.member.3.Dimensions.member.1.Name" => "my_dim_1",
+      "MetricData.member.3.Dimensions.member.1.Value" => "dim_1_value",
+      "MetricData.member.3.Dimensions.member.2.Name" => "my_dim_2",
+      "MetricData.member.3.Dimensions.member.2.Value" => "dim_2_value",
+      "MetricData.member.3.MetricName" => "My Metric Name",
+      "MetricData.member.3.StatisticValues.Maximum" => 6,
+      "MetricData.member.3.StatisticValues.Minimum" => 4,
+      "MetricData.member.3.StatisticValues.SampleCount" => 3,
+      "MetricData.member.3.StatisticValues.Sum" => 15,
+      "MetricData.member.3.StorageResolution" => 1,
+      # "MetricData.member.3.Timestamp" => 1529463103000,
+      "MetricData.member.3.Unit" => "Count",
+      "MetricData.member.3.Value" => 1.0,
+      "Namespace" => "My Name Space",
+      "Version" => "2010-08-01",
+    }
+    assert expected == Cloudwatch.put_metric_data(metric_data, "My Name Space").params
+  end
+
 end


### PR DESCRIPTION
- Parse the dimensions value by format_param/1 instead of format/2
- Add Example document (as doctest for minimum parameter set)
- Add UT. put_metric_data for full parameter set